### PR TITLE
Fix cargo-faasta to deploy native .so artifacts (use --artifact-path)

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -120,39 +120,33 @@ async fn main() {
                 }
             };
 
-            // Path to the WASM file
-            // Note: Rust compiler output converts hyphens to underscores, so we need to
-            // handle this conversion to find the compiled WASM file
-            // This is a client-side only conversion that's needed to locate the compiled artifact
-            let wasm_path = if let Some(explicit_path) = &args.wasm_path {
-                // User provided an explicit WASM path
+            // Path to the shared library artifact
+            // Note: Rust compiler output converts hyphens to underscores in artifact names.
+            let artifact_path = if let Some(explicit_path) = &args.artifact_path {
+                // User provided an explicit artifact path
                 PathBuf::from(explicit_path)
             } else {
                 // Auto-detect based on package name
-                let rust_compiled_name = package_name.replace('-', "_");
-                let wasm_filename = format!("{rust_compiled_name}.wasm");
-
-                // Path to the compiled WASM file (uses Rust's converted name)
-                target_directory
-                    .join("wasm32-wasip2")
-                    .join("release")
-                    .join(wasm_filename)
+                run::default_artifact_path(&target_directory, &package_name)
             };
 
-            // For explicit WASM paths, we'll use the filename without extension as the function name
+            // For explicit artifact paths, we'll use the filename without extension as the function name
             // unless the user specified a function name
-            let function_name = if args.wasm_path.is_some() && args.function_name.is_some() {
-                // User provided both WASM path and function name - use the explicit function name
+            let function_name = if args.artifact_path.is_some() && args.function_name.is_some() {
+                // User provided both artifact path and function name - use the explicit function name
                 args.function_name.clone().unwrap()
-            } else if args.wasm_path.is_some() {
-                // User provided WASM path but no function name - derive from filename
-                wasm_path
+            } else if args.artifact_path.is_some() {
+                // User provided artifact path but no function name - derive from filename
+                artifact_path
                     .file_stem()
                     .and_then(|s| s.to_str())
+                    .map(|s| s.trim_start_matches("lib").to_owned())
                     .map(|s| s.to_owned())
                     .unwrap_or_else(|| {
                         spinner.finish_and_clear();
-                        eprintln!("Error: Could not determine function name from WASM filename");
+                        eprintln!(
+                            "Error: Could not determine function name from artifact filename"
+                        );
                         exit(1);
                     })
             } else {
@@ -162,38 +156,40 @@ async fn main() {
 
             spinner.set_message(format!("Uploading function '{function_name}' to server..."));
 
-            if !wasm_path.exists() {
+            if !artifact_path.exists() {
                 spinner.finish_and_clear();
-                if args.wasm_path.is_some() {
+                if args.artifact_path.is_some() {
                     eprintln!(
-                        "Error: Could not find WASM file at: {}",
-                        wasm_path.display()
+                        "Error: Could not find shared library artifact at: {}",
+                        artifact_path.display()
                     );
                 } else {
                     eprintln!(
-                        "Error: Could not find compiled WASM at: {}",
-                        wasm_path.display()
+                        "Error: Could not find compiled shared library at: {}",
+                        artifact_path.display()
                     );
                     eprintln!("Options:");
-                    eprintln!("  1. Run 'cargo faasta build' first with wasm32-wasip2 target");
-                    eprintln!("  2. Specify an explicit WASM file path with --wasm-path");
+                    eprintln!(
+                        "  1. Run 'cargo faasta build' first with x86_64-unknown-linux-gnu target"
+                    );
+                    eprintln!("  2. Specify an explicit artifact path with --artifact-path");
                     eprintln!();
                     eprintln!(
-                        "If your WASM file is in a non-standard location or has a different name, use:"
+                        "If your artifact file is in a non-standard location or has a different name, use:"
                     );
-                    eprintln!("  cargo faasta deploy --wasm-path PATH/TO/YOUR/FILE.wasm");
+                    eprintln!("  cargo faasta deploy --artifact-path PATH/TO/YOUR/FILE.so");
                 }
                 exit(1);
             }
 
-            // Read the WASM file
-            let wasm_data = match std::fs::read(&wasm_path) {
+            // Read the shared library artifact
+            let artifact_data = match std::fs::read(&artifact_path) {
                 Ok(data) => {
-                    // Check WASM file size client-side as well (30MB max)
+                    // Check artifact size client-side as well (30MB max)
                     if data.len() > faasta_interface::MAX_WASM_SIZE {
                         spinner.finish_and_clear();
                         eprintln!(
-                            "Error: WASM file too large ({}MB). Maximum allowed size is 30MB.",
+                            "Error: Artifact file too large ({}MB). Maximum allowed size is 30MB.",
                             data.len() / 1024 / 1024
                         );
                         exit(1);
@@ -202,7 +198,7 @@ async fn main() {
                 }
                 Err(e) => {
                     spinner.finish_and_clear();
-                    eprintln!("Failed to read WASM file: {e}");
+                    eprintln!("Failed to read artifact file: {e}");
                     exit(1);
                 }
             };
@@ -232,7 +228,7 @@ async fn main() {
             // Publish the function
             let auth_token = format!("{github_username}:{github_token}");
             match client
-                .publish(wasm_data, function_name.clone(), auth_token)
+                .publish(artifact_data, function_name.clone(), auth_token)
                 .await
             {
                 Ok(Ok(message)) => {
@@ -338,82 +334,78 @@ async fn main() {
                     }
                 };
 
-                // Path to the WASM file
-                // Note: Rust compiler output converts hyphens to underscores, so we need to
-                // handle this conversion to find the compiled WASM file
-                let wasm_path = if let Some(explicit_path) = &build_args.wasm_path {
-                    // User provided an explicit WASM path
+                // Path to the shared library artifact
+                // Note: Rust compiler output converts hyphens to underscores in artifact names.
+                let artifact_path = if let Some(explicit_path) = &build_args.artifact_path {
+                    // User provided an explicit artifact path
                     PathBuf::from(explicit_path)
                 } else {
                     // Auto-detect based on package name
-                    let rust_compiled_name = package_name.replace('-', "_");
-                    let wasm_filename = format!("{rust_compiled_name}.wasm");
-
-                    // Path to the compiled WASM file (uses Rust's converted name)
-                    target_directory
-                        .join("wasm32-wasip2")
-                        .join("release")
-                        .join(wasm_filename)
+                    run::default_artifact_path(&target_directory, &package_name)
                 };
 
-                // For explicit WASM paths, we'll use the filename without extension as the function name
+                // For explicit artifact paths, we'll use the filename without extension as the function name
                 // unless the user specified a function name
-                let function_name =
-                    if build_args.wasm_path.is_some() && build_args.function_name.is_some() {
-                        // User provided both WASM path and function name - use the explicit function name
-                        build_args.function_name.clone().unwrap()
-                    } else if build_args.wasm_path.is_some() {
-                        // User provided WASM path but no function name - derive from filename
-                        wasm_path
-                            .file_stem()
-                            .and_then(|s| s.to_str())
-                            .map(|s| s.to_owned())
-                            .unwrap_or_else(|| {
-                                spinner.finish_and_clear();
-                                eprintln!(
-                                    "Error: Could not determine function name from WASM filename"
-                                );
-                                exit(1);
-                            })
-                    } else {
-                        // Standard flow - use the package name
-                        package_name.clone()
-                    };
+                let function_name = if build_args.artifact_path.is_some()
+                    && build_args.function_name.is_some()
+                {
+                    // User provided both artifact path and function name - use the explicit function name
+                    build_args.function_name.clone().unwrap()
+                } else if build_args.artifact_path.is_some() {
+                    // User provided artifact path but no function name - derive from filename
+                    artifact_path
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .map(|s| s.trim_start_matches("lib").to_owned())
+                        .map(|s| s.to_owned())
+                        .unwrap_or_else(|| {
+                            spinner.finish_and_clear();
+                            eprintln!(
+                                "Error: Could not determine function name from artifact filename"
+                            );
+                            exit(1);
+                        })
+                } else {
+                    // Standard flow - use the package name
+                    package_name.clone()
+                };
 
-                if !wasm_path.exists() {
+                if !artifact_path.exists() {
                     spinner.finish_and_clear();
-                    if build_args.wasm_path.is_some() {
+                    if build_args.artifact_path.is_some() {
                         eprintln!(
-                            "Error: Could not find WASM file at: {}",
-                            wasm_path.display()
+                            "Error: Could not find shared library artifact at: {}",
+                            artifact_path.display()
                         );
                     } else {
                         eprintln!(
-                            "Error: Could not find compiled WASM at: {}",
-                            wasm_path.display()
+                            "Error: Could not find compiled shared library at: {}",
+                            artifact_path.display()
                         );
                         eprintln!("Options:");
-                        eprintln!("  1. Run 'cargo faasta build' first with wasm32-wasip2 target");
-                        eprintln!("  2. Specify an explicit WASM file path with --wasm-path");
+                        eprintln!(
+                            "  1. Run 'cargo faasta build' first with x86_64-unknown-linux-gnu target"
+                        );
+                        eprintln!("  2. Specify an explicit artifact path with --artifact-path");
                         eprintln!();
                         eprintln!(
-                            "If your WASM file is in a non-standard location or has a different name, use:"
+                            "If your artifact file is in a non-standard location or has a different name, use:"
                         );
                         eprintln!(
-                            "  cargo faasta build --deploy --wasm-path PATH/TO/YOUR/FILE.wasm"
+                            "  cargo faasta build --deploy --artifact-path PATH/TO/YOUR/FILE.so"
                         );
                     }
                     exit(1);
                 }
 
-                // Read the WASM file
-                let wasm_data = match std::fs::read(&wasm_path) {
+                // Read the shared library artifact
+                let artifact_data = match std::fs::read(&artifact_path) {
                     Ok(data) => {
-                        // Check WASM file size client-side as well (30MB max)
+                        // Check artifact size client-side as well (30MB max)
                         if data.len() > faasta_interface::MAX_WASM_SIZE {
                             spinner.finish_and_clear();
                             eprintln!(
-                                "Error: WASM file too large ({}MB). Maximum allowed size is 30MB.",
+                                "Error: Artifact file too large ({}MB). Maximum allowed size is 30MB.",
                                 data.len() / 1024 / 1024
                             );
                             exit(1);
@@ -422,7 +414,7 @@ async fn main() {
                     }
                     Err(e) => {
                         spinner.finish_and_clear();
-                        eprintln!("Failed to read WASM file: {e}");
+                        eprintln!("Failed to read artifact file: {e}");
                         exit(1);
                     }
                 };
@@ -455,7 +447,7 @@ async fn main() {
                 // Publish the function
                 let auth_token = format!("{github_username}:{github_token}");
                 match client
-                    .publish(wasm_data, function_name.clone(), auth_token)
+                    .publish(artifact_data, function_name.clone(), auth_token)
                     .await
                 {
                     Ok(Ok(message)) => {
@@ -783,9 +775,9 @@ struct DeployArgs {
     #[arg(long)]
     skip_auth: bool,
 
-    /// Explicit path to WASM file (overrides automatic detection)
+    /// Explicit path to compiled shared library artifact (overrides automatic detection)
     #[arg(long)]
-    wasm_path: Option<String>,
+    artifact_path: Option<String>,
 
     /// Function name to use (if different from package name)
     #[arg(long)]
@@ -802,9 +794,9 @@ struct BuildArgs {
     #[arg(short, long)]
     deploy: bool,
 
-    /// Explicit path to WASM file (overrides automatic detection)
+    /// Explicit path to compiled shared library artifact (overrides automatic detection)
     #[arg(long)]
-    wasm_path: Option<String>,
+    artifact_path: Option<String>,
 
     /// Function name to use (if different from package name)
     #[arg(long)]

--- a/cli/src/run.rs
+++ b/cli/src/run.rs
@@ -197,18 +197,27 @@ pub fn build_project(package_root: &PathBuf) -> Result<(), io::Error> {
     }
 
     let status = std::process::Command::new("cargo")
-        .args(["zigbuild", "--release", "--target", "x86_64-unknown-linux-gnu"])
+        .args([
+            "zigbuild",
+            "--release",
+            "--target",
+            "x86_64-unknown-linux-gnu",
+        ])
         .current_dir(package_root)
         .status()
         .unwrap_or_else(|e| {
             spinner.finish_and_clear();
             eprintln!("Failed to run cargo zigbuild, did you install it?: {e}");
             let _status = std::process::Command::new("cargo")
-                .args(["binstall", "cargo-zigbuild"]).status().unwrap_or_else(|e| {
-                eprintln!("Failed to run cargo binstall, did you install it?: {e}");
-                std::process::Command::new("cargo")
-                .args(["install", "cargo-zigbuild"]).status().unwrap_or_else(|_e| std::process::exit(1))
-            });
+                .args(["binstall", "cargo-zigbuild"])
+                .status()
+                .unwrap_or_else(|e| {
+                    eprintln!("Failed to run cargo binstall, did you install it?: {e}");
+                    std::process::Command::new("cargo")
+                        .args(["install", "cargo-zigbuild"])
+                        .status()
+                        .unwrap_or_else(|_e| std::process::exit(1))
+                });
             exit(1);
         });
 
@@ -223,6 +232,15 @@ pub fn build_project(package_root: &PathBuf) -> Result<(), io::Error> {
     Ok(())
 }
 
+pub fn default_artifact_path(target_directory: &StdPath, package_name: &str) -> PathBuf {
+    let rust_compiled_name = package_name.replace('-', "_");
+    let so_filename = format!("lib{rust_compiled_name}.so");
+    target_directory
+        .join("x86_64-unknown-linux-gnu")
+        .join("release")
+        .join(so_filename)
+}
+
 // The function to handle the run command
 pub async fn handle_run(port: u16) -> io::Result<()> {
     // Get project information
@@ -235,38 +253,25 @@ pub async fn handle_run(port: u16) -> io::Result<()> {
     // Build the project first
     build_project(&package_root)?;
 
-    // Get the full WASM file path - use same logic as in deploy
-    let rust_compiled_name = package_name.replace('-', "_");
-    let wasm_filename = format!("{rust_compiled_name}.wasm");
-    let wasm_path = target_directory
-        .join("wasm32-wasip2")
-        .join("release")
-        .join(wasm_filename);
+    // Get the full shared-library path - use same logic as in deploy
+    let artifact_path = default_artifact_path(&target_directory, &package_name);
 
-    // Ensure the WASM file exists
-    if !wasm_path.exists() {
+    // Ensure the shared library exists
+    if !artifact_path.exists() {
         eprintln!(
-            "Error: Could not find compiled WASM at: {}",
-            wasm_path.display()
+            "Error: Could not find compiled shared library at: {}",
+            artifact_path.display()
         );
         eprintln!("Build seems to have failed or produced output in a different location.");
         exit(1);
     }
 
-    println!("Starting local server on port {port}...");
-    let status = std::process::Command::new("wasmtime")
-        .args(["serve", &wasm_path.to_string_lossy()])
-        .current_dir(&package_root)
-        .status()
-        .unwrap_or_else(|e| {
-            eprintln!("Failed to run wasmtime serve: {e}");
-            exit(1);
-        });
-
-    if !status.success() {
-        eprintln!("wasmtime serve exited with an error");
-        exit(1);
-    }
+    println!("Compiled shared library: {}", artifact_path.display());
+    eprintln!("Local run is currently unsupported for native .so functions.");
+    eprintln!(
+        "Deploy with 'cargo faasta deploy --artifact-path <path>' or run a Faasta server locally."
+    );
+    let _ = (port, package_root);
 
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- The server expects native shared-library artifacts (`.so`) but the CLI still assumed WASM outputs and exposed `--wasm-path` flags, causing deploy/run to fail or be misleading.

### Description
- Replace WASM-focused flows with native artifact support by switching the CLI to expect `.so` artifacts and reading them as the upload payload instead of WASM files.
- Add `run::default_artifact_path` to compute the default artifact location `target/x86_64-unknown-linux-gnu/release/lib<crate>.so` and use it for auto-detection in build/deploy/run flows.
- Rename CLI flags and docs from `--wasm-path` to `--artifact-path`, and derive function names from `lib<name>.so` filenames (trimming the `lib` prefix when present).
- Update `cargo faasta run` to stop launching `wasmtime` for local runs of native artifacts; it now validates the `.so` and prints a clear message that local run is unsupported for `.so` artifacts.
- Improve some build helper command handling (consistent `cargo` arg formatting and fallback install behavior for `cargo-zigbuild`).
- Files changed: `cli/src/main.rs`, `cli/src/run.rs`.

### Testing
- Ran `cargo fmt --all` (succeeded).
- Ran `cargo check -p cargo-faasta` in the workspace (succeeded, `cargo-faasta` finished checking).
- Verified CLI compiles and updated help text via the type-checking/build step (no runtime integration tests were executed in this patch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992e647a78c832d84af9b61f8ba3a8e)